### PR TITLE
Update test_custom_content_injection.py

### DIFF
--- a/tests/test_custom_content_injection.py
+++ b/tests/test_custom_content_injection.py
@@ -12,7 +12,7 @@ class TestContentInjection(ZmirrorTestBase):
         my_host_name = 'b.test.com'
         my_host_scheme = 'https://'
         target_domain = 'www.kernel.org'
-        target_scheme = 'http://'
+        target_scheme = 'https://'
 
         force_https_domains = ('bugzilla.kernel.org',)
 


### PR DESCRIPTION
It seems kernel.org does not support http now, try to change it to https